### PR TITLE
PG14 Task Manager fix

### DIFF
--- a/ipapp/task/db.py
+++ b/ipapp/task/db.py
@@ -836,7 +836,7 @@ class Db:
                 "VALUES(COALESCE($1, NOW()),$2,$3,$4,$5,"
                 "make_interval(secs=>$6::float),$7,$8) "
                 "RETURNING id, "
-                "greatest(extract(epoch from eta-NOW()), 0) as delay"
+                "greatest(extract(epoch from eta-NOW()), 0)::float as delay"
             ) % self._cfg.db_schema
             query_params: Tuple[Any, ...] = (
                 eta,
@@ -855,7 +855,7 @@ class Db:
                 "VALUES(COALESCE($1, NOW()),$2,$3,$4,$5,"
                 "make_interval(secs=>$6::float)) "
                 "RETURNING id, "
-                "greatest(extract(epoch from eta-NOW()), 0) as delay"
+                "greatest(extract(epoch from eta-NOW()), 0)::float as delay"
             ) % self._cfg.db_schema
             query_params = (
                 eta,
@@ -915,7 +915,7 @@ class Db:
 
     async def task_next_delay(self, *, lock: bool = False) -> Optional[float]:
         query = (  # nosec
-            "SELECT EXTRACT(EPOCH FROM eta-NOW())t "
+            "SELECT EXTRACT(EPOCH FROM eta-NOW())::float t "
             "FROM %s.task_pending "
             "WHERE "
             "status=ANY(ARRAY['pending'::%s.task_status,"


### PR DESCRIPTION
from Postgres14 [changelog](https://www.postgresql.org/docs/14/release-14.html
):

_Change EXTRACT() to return type numeric instead of float8 (Peter Eisentraut)
This avoids loss-of-precision issues in some usages. The old behavior can still be obtained by using the old underlying function date_part().
Also, EXTRACT(date) now throws an error for units that are not part of the date data type._

Пример:
`SELECT pg_typeof(extract(epoch from now()))`
- PG <14  => `double precision`
- PG =14  => `numeric`


По-умолчанию, asyncpg преобразует numeric в 'decimal.Decimal’, что приводит к операциям с несовместимыми типами, например [тут](https://github.com/inplat/ipapp/blob/master/ipapp/task/db.py#L493) (при time_delay - decimal.Decimal)
