### PR TITLE
Fix data loss for named logger adapters

### DIFF
--- a/ipapp/logger/adapters/_abc.py
+++ b/ipapp/logger/adapters/_abc.py
@@ -18,7 +18,6 @@ class AbcConfig(BaseModel):
 
 
 class AbcAdapter(ABC):
-    name: str = ''
     cfg: Optional[AbcConfig] = None
 
     @abstractmethod
@@ -32,6 +31,10 @@ class AbcAdapter(ABC):
     @abstractmethod
     async def stop(self) -> None:
         pass
+
+    @property
+    def name(self) -> str:
+        return self.__class__.__name__
 
 
 __all__ = [

--- a/ipapp/logger/adapters/prometheus.py
+++ b/ipapp/logger/adapters/prometheus.py
@@ -108,7 +108,6 @@ class PrometheusConfig(AbcConfig):
 
 
 class PrometheusAdapter(AbcAdapter):
-    name = 'prometheus'
     cfg: PrometheusConfig
 
     def __init__(self, cfg: PrometheusConfig) -> None:
@@ -145,9 +144,7 @@ class PrometheusAdapter(AbcAdapter):
 
     def handle(self, span: Span) -> None:
         if self.cfg is None:
-            raise AdapterConfigurationError(
-                '%s is not configured' % self.__class__.__name__
-            )
+            raise AdapterConfigurationError('%s is not configured' % self.name)
 
         name = span.get_name4adapter(self.name)
         tags = span.get_tags4adapter(self.name)
@@ -167,6 +164,4 @@ class PrometheusAdapter(AbcAdapter):
 
     async def stop(self) -> None:
         if self.cfg is None:
-            raise AdapterConfigurationError(
-                '%s is not configured' % self.__class__.__name__
-            )
+            raise AdapterConfigurationError('%s is not configured' % self.name)

--- a/ipapp/logger/adapters/requests.py
+++ b/ipapp/logger/adapters/requests.py
@@ -185,7 +185,6 @@ class RequestsConfig(AbcConfig):
 
 
 class RequestsAdapter(AbcAdapter):
-    name = 'requests'
     cfg: RequestsConfig
 
     _QUERY_COLS = (
@@ -479,9 +478,7 @@ class RequestsAdapter(AbcAdapter):
 
     async def _send_loop(self) -> None:
         if self.logger is None:
-            raise AdapterConfigurationError(
-                '%s is not configured' % self.__class__.__name__
-            )
+            raise AdapterConfigurationError('%s is not configured' % self.name)
         while not self._stopping:
             try:
                 async with self._send_lock:

--- a/ipapp/logger/adapters/sentry.py
+++ b/ipapp/logger/adapters/sentry.py
@@ -20,7 +20,6 @@ class SentryConfig(AbcConfig):
 
 
 class SentryAdapter(AbcAdapter):
-    name = 'sentry'
     cfg: SentryConfig
     logger: 'ipapp.logger.Logger'
 
@@ -33,7 +32,7 @@ class SentryAdapter(AbcAdapter):
         self.logger = logger
         if self.cfg.dsn is None:
             raise AdapterConfigurationError(
-                '%s dsn is not configured' % self.__class__.__name__
+                '%s dsn is not configured' % self.name
             )
         self.client = Client(dsn=self.cfg.dsn)
         Hub.current.bind_client(self.client)

--- a/ipapp/logger/adapters/zipkin.py
+++ b/ipapp/logger/adapters/zipkin.py
@@ -36,7 +36,6 @@ class ZipkinConfig(AbcConfig):
 
 
 class ZipkinAdapter(AbcAdapter):
-    name = 'zipkin'
     cfg: ZipkinConfig
     logger: 'ipapp.logger.Logger'
 
@@ -56,9 +55,7 @@ class ZipkinAdapter(AbcAdapter):
 
     def handle(self, span: Span) -> None:
         if self.tracer is None:
-            raise AdapterConfigurationError(
-                '%s is not configured' % self.__class__.__name__
-            )
+            raise AdapterConfigurationError('%s is not configured' % self.name)
 
         tracer_span = self.tracer.to_span(
             azh.TraceContext(
@@ -91,8 +88,6 @@ class ZipkinAdapter(AbcAdapter):
 
     async def stop(self) -> None:
         if self.tracer is None:
-            raise AdapterConfigurationError(
-                '%s is not configured' % self.__class__.__name__
-            )
+            raise AdapterConfigurationError('%s is not configured' % self.name)
 
         await self.tracer.close()

--- a/ipapp/logger/logger.py
+++ b/ipapp/logger/logger.py
@@ -86,7 +86,7 @@ class Logger:
             raise UserWarning('Invalid adapter')
 
         self._configs.append(adapter.start(self))
-        self.adapters[adapter.__class__.__name__] = adapter
+        self.adapters[adapter.name] = adapter
         return adapter
 
     def add_before_handle_cb(self, fn: Callable[[Span], None]) -> None:

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -224,7 +224,6 @@ async def test_span_skip():
 
 async def test_span():
     class TestAdapter(AbcAdapter):
-        name = 'test_adapter'
         started = False
         stopped = False
         handled: List[Span] = []

--- a/tests/test_logger_requests.py
+++ b/tests/test_logger_requests.py
@@ -47,17 +47,31 @@ async def test_success(loop, postgres_url: str):
     error = 'e1'
     tags = {'t1': '1', 't2': '2'}
 
-    with app.logger.span_new(
-        name='request1', kind=HttpSpan.KIND_SERVER, cls=HttpSpan
-    ) as span:
-        span.annotate(HttpSpan.ANN_REQUEST_HDRS, req_hdrs)
-        span.annotate(HttpSpan.ANN_REQUEST_BODY, req_body)
-        span.annotate(HttpSpan.ANN_RESPONSE_HDRS, resp_hdrs)
-        span.annotate(HttpSpan.ANN_RESPONSE_BODY, resp_body)
+    with app.logger.span_new(kind=HttpSpan.KIND_SERVER, cls=HttpSpan) as span:
+        span.annotate4adapter(
+            app.logger.ADAPTER_REQUESTS, HttpSpan.ANN_REQUEST_HDRS, req_hdrs
+        )
+        span.annotate4adapter(
+            app.logger.ADAPTER_REQUESTS, HttpSpan.ANN_REQUEST_BODY, req_body
+        )
+        span.annotate4adapter(
+            app.logger.ADAPTER_REQUESTS, HttpSpan.ANN_RESPONSE_HDRS, resp_hdrs
+        )
+        span.annotate4adapter(
+            app.logger.ADAPTER_REQUESTS, HttpSpan.ANN_RESPONSE_BODY, resp_body
+        )
         span.error(Exception(error))
-        span.tag(HttpSpan.TAG_HTTP_STATUS_CODE, status_code)
-        span.tag(HttpSpan.TAG_HTTP_URL, req_url)
-        span.tag(HttpSpan.TAG_HTTP_METHOD, method)
+        span.set_tag4adapter(
+            app.logger.ADAPTER_REQUESTS,
+            HttpSpan.TAG_HTTP_STATUS_CODE,
+            status_code,
+        )
+        span.set_tag4adapter(
+            app.logger.ADAPTER_REQUESTS, HttpSpan.TAG_HTTP_URL, req_url
+        )
+        span.set_tag4adapter(
+            app.logger.ADAPTER_REQUESTS, HttpSpan.TAG_HTTP_METHOD, method
+        )
         for k, v in tags.items():
             span.tag(k, v)
 


### PR DESCRIPTION
Starting from version 1.3.6, metrics are no longer sent to Prometheus.
Found and fixed error in commit [d3d4c86] while partially refactoring the code.